### PR TITLE
Refactor secrets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read
@@ -49,7 +49,7 @@ jobs:
   codeql:
     if: ${{ !cancelled() }}
     needs: [ analysis ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Report status

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -12,7 +12,7 @@ permissions: read-all # zizmor: ignore[excessive-permissions] Recommended permis
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,19 @@ permissions: {}
 jobs:
   release:
     runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
+
+    environment:
+      name: release
+      deployment: false
+
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
 
@@ -29,9 +38,15 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           filter: 'tree:0'
-          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+          persist-credentials: false
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: release
 
       - name: Create release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   release:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
 
     concurrency:
       group: ${{ github.workflow }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           DRAFT: ${{ inputs.publish != true }}
           VERSION: ${{ inputs.version }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const draft = process.env.DRAFT === 'true';

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   tag:
     name: tag
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
     if: github.event.repository.fork == false
 
     permissions:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
- Use GitHub token broker instead of `COSTELLOBOT_TOKEN`.
- Remove redundant credentials usage.
- Pin runner labels to specific versions instead of latest.